### PR TITLE
fix: Reduce the maximum timeout for the power-on command

### DIFF
--- a/intg-stormaudio/device.py
+++ b/intg-stormaudio/device.py
@@ -23,7 +23,7 @@ _LOG = logging.getLogger(Loggers.DEVICE)
 
 MIN_VOLUME = 0
 MAX_VOLUME = 100
-MAX_TIME_OUT = 9 # current command timeout is 10 seconds, therefore we need to be below of that threshold.
+MAX_TIME_OUT = 9  # current command timeout is 10 seconds, therefore we need to be below of that threshold.
 
 
 class StormAudioDevice(PersistentConnectionDevice):


### PR DESCRIPTION
The remote currently has a fixed command timeout of 10 seconds, which makes this solution actually not work.